### PR TITLE
fix: resolve string parameter error for eval() function

### DIFF
--- a/lib/core/parser.ts
+++ b/lib/core/parser.ts
@@ -132,15 +132,6 @@ export default class Parser {
                 return result
             })
 
-            // Replace the parameter expressions with there actual value eg: user.name => John Doe
-            condition = condition.replace(REGEX_PARAMETER_EXPRESSION, (match) => {
-
-                if (!this.parameters) return match;
-
-                const fn = new Function(...Object.keys(this.parameters), `return ${match.trim()}`);
-                return fn(...Object.values(this.parameters))
-            });
-
             // Final condition execution
             const fn = new Function(...Object.keys(this.parameters || []), `return ${condition}`);
             return fn(...Object.values(this.parameters || []));


### PR DESCRIPTION
While using a string datatype parameter in @if condition it throws error because of double checks.

- It first replace the parameter value like username
- And in the further code if username's value was "fake_user" then it runs the condition (fake_user) which is techinaly wrong because there is no fake_user parameter
- In this commit the match checking replacing the parameter is removed from eval function of class Parser