### PR TITLE
V2 - Add support to call functions in function arguments

### DIFF
--- a/packages/zare/lib/core/parser.ts
+++ b/packages/zare/lib/core/parser.ts
@@ -29,6 +29,7 @@ const REGEX_PATH_STRING = /"(\.?\.?(\/[\w.\- ]+)*\/?|\.{1,2})"/;
 const REGEX_CSS_PATH = /^"(\.?\/.*)"$/;
 const REGEX_JS_PATH = /^"(\.?\/.*)"$/;
 const REGEX_FN_PARAMS = /^[a-zA-Z0-9.]+$/;
+const REGEX_FN_CALLS_IN_FN_ARGS = /\b([a-zA-Z_]\w*)\s*\(\s*([^()]*?)\s*\)/;
 const REGEX_EACH_EXPRESSION = /\((.*?)\)/;
 
 export default class Parser {
@@ -279,6 +280,12 @@ export default class Parser {
                 if (Number(trimmed)) fnArgs.push(trimmed);
                 else if (REGEX_FN_PARAMS.test(trimmed))
                     fnArgs.push(this.getValue(this.parameters, trimmed) || '');
+                else if (REGEX_FN_CALLS_IN_FN_ARGS.test(trimmed)) {
+                    const functionProperties = this.extractFunctionCallValues(`@${trimmed}`);
+                    const fn = this.functions.lookup(functionProperties === null || functionProperties === void 0 ? void 0 : functionProperties.fnName);
+                    const fnReturnValue = fn(...(functionProperties === null || functionProperties === void 0 ? void 0 : functionProperties.fnArgs) || []);
+                    fnArgs.push(fnReturnValue);
+                }
                 else if ((trimmed.startsWith(`"`) || trimmed.startsWith(`'`)) && (trimmed.endsWith(`"`) || trimmed.endsWith(`'`))) fnArgs.push(trimmed.slice(1, -1))
                 else
                     fnArgs.push(trimmed);

--- a/packages/zare/tests/parser.test.ts
+++ b/packages/zare/tests/parser.test.ts
@@ -73,6 +73,21 @@ describe('Parser', () => {
             expect(render(testCode).trim()).toBe("HELLO");
         });
 
+        it("should evaluate function call with function call as argument", () => {
+
+            const testCode = `use math
+
+            fn sum(a, b) {
+                return Number(a) + Number(b)
+            }
+            serve (
+                @pow(sum(2, 3), 2)
+            )
+            `;
+
+            expect(render(testCode, {}).trim()).toBe("25");
+        });
+
         it("should evaluate function call with parameter", () => {
 
             const testCode = `use string


### PR DESCRIPTION
# Support for function calls in function arguments

Before this users can't call a function in the function argument, But now I add an extra check in `extractFunctionCallValues` of `Parser class` to check if the function call happens and if yes do call the function and take the return value.